### PR TITLE
Add minimal logging and run script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.1",
-        "express-http-proxy": "^1.6.3"
-      },
-      "devDependencies": {
+        "express-http-proxy": "^1.6.3",
         "url": "^0.11.0",
         "ws": "^8.8.1"
       }
@@ -476,8 +474,7 @@
     "node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
-      "dev": true
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
     },
     "node_modules/qs": {
       "version": "6.10.3",
@@ -498,7 +495,6 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
       "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -649,7 +645,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
-      "dev": true,
       "dependencies": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -675,7 +670,6 @@
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
       "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1044,8 +1038,7 @@
     "punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
-      "dev": true
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
     },
     "qs": {
       "version": "6.10.3",
@@ -1058,8 +1051,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "dev": true
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
     },
     "range-parser": {
       "version": "1.2.1",
@@ -1168,7 +1160,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
-      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -1188,7 +1179,6 @@
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
       "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
-      "dev": true,
       "requires": {}
     }
   }

--- a/run
+++ b/run
@@ -1,0 +1,8 @@
+# cd root
+kubectl ws
+# cd appstudio
+kubectl ws appstudio
+# will include the workspace context etc
+export KCP_SERVER_URL=$(oc whoami --show-server)
+echo "Connecting to API Server: $KCP_SERVER_URL"
+HAC_CORE_ORIGIN=https://prod.foo.redhat.com:1337 node server.js

--- a/server.js
+++ b/server.js
@@ -29,7 +29,9 @@ const proxyOptions = {
   proxyReqPathResolver: req => {
     const requestedPath = url.parse(req.originalUrl).path;
     let updatedPath = kcpPath + url.parse(req.originalUrl).path;
-
+     
+    console.log(`PROXY [ requestedPath ${requestedPath} ]`); 
+    console.log(`PROXY [ updatedPath ${updatedPath} ]`);  
     if (requestedPath.includes('/apis/tenancy.kcp.dev/v1beta1/workspaces')) {
       // "Create workspace" doesn't work with the workspace name in the path
       updatedPath = req.method === 'POST' ? (kcpPath + '/apis/tenancy.kcp.dev/v1beta1/workspaces') : updatedPath;
@@ -38,9 +40,15 @@ const proxyOptions = {
   },
 };
 
+let logstatus = (req, res, next) => {  
+  console.log(`PROXY [ ${req.method}:${req.url} ${res.statusCode} ]`);
+  next();
+};
+
 // Proxy to KCP server
 const apiProxy = proxy(kcpHost, proxyOptions);
-app.use(['/apis', '/api/v1'], apiProxy);
+app.use(logstatus);
+app.use(['/apis', '/api/v1'], apiProxy); 
 
 // Start server
 const server = app.listen(3000, () => {


### PR DESCRIPTION
This pull request add some minor changes to the proxy.

1. a `run` script  which computes the configuration for app studio and launches the server. 
2. logging which shows the re-written API endpoints and the status of the API request so you can tell if some api returned errors or were missing as a debug tool.  